### PR TITLE
Prefer CommonJS over window env

### DIFF
--- a/my.class.js
+++ b/my.class.js
@@ -7,10 +7,10 @@
     define([], function () {
       return my;
     });
-  else if (typeof window !== 'undefined')
-    window.my = my;
-  else
+  else if(typeof module !== 'undefinded')
     module.exports = my;
+  else /*if (typeof window !== 'undefined')*/
+    window.my = my;
 
   //============================================================================
   // @method my.Class


### PR DESCRIPTION
Hi,
I've patched my.class.js to support running in CommonJS environment when running inside a browser.
With existing code, we never register in module.exports, since "window" is present.

Note, if existing code is using a global "module" for something else, then we will overwrite any exports property there, and we wont register on window..
Maybe window.my should always be configured if window is present?
